### PR TITLE
Commit1

### DIFF
--- a/src/main/java/Problem3/Book.java
+++ b/src/main/java/Problem3/Book.java
@@ -37,11 +37,11 @@ public abstract class Book implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherBook.id) &&
-                author.equals(theOtherBook.author) &&
-                title.equals(theOtherBook.title);
+        //return id.equals(theOtherBook.id) &&
+          //      author.equals(theOtherBook.author) &&
+            //    title.equals(theOtherBook.title);
 
         // fix is here
-        // return id.equals(theOtherBook.id);
+         return id.equals(theOtherBook.id);
     }
 }

--- a/src/main/java/Problem3/BookFiction.java
+++ b/src/main/java/Problem3/BookFiction.java
@@ -1,5 +1,7 @@
 package Problem3;
 
+import java.util.UUID;
+
 public class BookFiction extends Book {
 
     private int lateFeePerDayInDollar = 2;
@@ -9,12 +11,16 @@ public class BookFiction extends Book {
     public BookFiction(String title, String author, String genres) {
         super(title, author);
         this.genres = genres;
+        this.id = UUID.randomUUID();
+        System.out.println(id);
     }
 
     // copy constructor
     public BookFiction(BookFiction anotherBook) {
         super(anotherBook);
         this.genres = anotherBook.genres;
+        this.id = anotherBook.id;
+        System.out.println(id);
     }
 
     @Override

--- a/src/main/java/Problem3/Movie.java
+++ b/src/main/java/Problem3/Movie.java
@@ -37,11 +37,11 @@ public abstract class Movie implements StoreMediaOperations {
         // The bug is caught when
         //  1. newly add tests fail while all old tests still pass
         //  2. remove the bug and use the fix below, all tests pass
-        return id.equals(theOtherMovie.id) &&
-                rating.equals(theOtherMovie.rating) &&
-                title.equals(theOtherMovie.title);
+        //return id.equals(theOtherMovie.id) &&
+          //      rating.equals(theOtherMovie.rating) &&
+            //    title.equals(theOtherMovie.title);
 
         // fix is here
-        //return this.id == ((Movie) obj).id;
+        return this.id == ((Movie) obj).id;
     }
 }

--- a/src/test/java/Problem3Test.java
+++ b/src/test/java/Problem3Test.java
@@ -7,11 +7,42 @@ public class Problem3Test {
     @Test
     public void catchTheBugInBook() {
         // quiz
+        Book b1 = new BookRomance("b1", "a1");
+        Book b2 = new BookFiction("b1", "a2", "g1");
+        assertFalse(b1.equals(b2));
+
+        BookRomance br1 = new BookRomance("br1", "a2");
+        BookRomance br2 = new BookRomance(br1);
+        assertTrue(br1.equals(br2));
+        br2 = new BookRomance("br2", "a1");
+        assertFalse(br1.equals(br2));
+
+        BookFiction f1 = new BookFiction("f1", "a1", "g1");
+        BookFiction f2 = new BookFiction(f1);
+        assertTrue(f1.equals(f2));
+        f2 = new BookFiction("f2", "a2", "g2");
+        assertFalse(f1.equals(f2));
     }
 
     @Test
     public void catchTheBugInMovie() {
         // quiz
+        Movie m1 = new MovieAction("m1", "movie");
+        Movie m2 = new MovieComedy("m2", "movie2");
+        assertFalse(m1.equals(m2));
+
+        MovieAction m3 = new MovieAction("m3", "movie3");
+        MovieAction m4 = new MovieAction(m3);
+        assertTrue(m3.equals(m4));
+        m4 = new MovieAction("m4", "movie4");
+        assertFalse(m3.equals(m4));
+
+        MovieComedy m5 = new MovieComedy("m5", "movie5");
+        MovieComedy m6 = new MovieComedy(m5);
+        assertTrue(m5.equals(m6));
+        m6 = new MovieComedy("m6", "movie6");
+        assertFalse(m5.equals(m6));
+
     }
 
     // DO NOT REMOVE OR CHANGE ANYTHING BELOW THIS!


### PR DESCRIPTION
I think that the reason why the tests are still able to pass with the bug in effect is because the id’s did not get declared in the anotherBook or anotherMovie constructors. The assert in the test code is also set to false, which ultimately makes it possible for the tests to pass even if the id is not the same as the one it’s being compared to. The initial return lets the test work with checking things other than the id, but with the fix, the test must specifically check for the id. 